### PR TITLE
SigGenSine added external signal option and starting window

### DIFF
--- a/testconfig/SigGenSine.json
+++ b/testconfig/SigGenSine.json
@@ -8,10 +8,9 @@
     },
     "args": {
         "band": 0,
-        "channels": [1],
-        "frequency": 240,
+        "frequency": 90,
         "use_uart": true,
-        "read_header": true,
-        "external_signal": true
+        "read_header": false,
+        "external_signal": false
     }
 }

--- a/testconfig/SigGenSine.json
+++ b/testconfig/SigGenSine.json
@@ -8,7 +8,10 @@
     },
     "args": {
         "band": 0,
-        "frequency": 90,
-        "use_uart": true
+        "channels": [1],
+        "frequency": 240,
+        "use_uart": true,
+        "read_header": true,
+        "external_signal": true
     }
 }


### PR DESCRIPTION
Added the options to SigGenSine.py and SigGenSine.json to use an external signal generator and save the sample starting window.