### PR TITLE
Enable multiconnections

### DIFF
--- a/radiant_test/radiant_helper.py
+++ b/radiant_test/radiant_helper.py
@@ -1,12 +1,12 @@
 import stationrc.remote_control
-import logging
+from collections import defaultdict
 
 
 RADIANT_NUM_CHANNELS = 24
 RADIANT_NUM_QUADS = 3
 RADIANT_SAMPLING_RATE = 3.2  # GHz
 
-RADIANT = None
+RADIANTs = defaultdict(None)
 
 uid_to_name_dict = {
     "e7e318ffb2ad88e35055334a3b82ba18": "ULB-002",
@@ -47,12 +47,13 @@ def quad_for_channel(channel_id):
         raise ValueError("Invalid channel id!")
 
 
-def get_radiant():
-    global RADIANT
+def get_radiant(host=None):
+    global RADIANTs
 
-    if RADIANT == None:
-        RADIANT = stationrc.remote_control.VirtualStation()
-    return RADIANT
+    if RADIANTs[host] is None:
+        RADIANTs[host] = stationrc.remote_control.VirtualStation(host)
+
+    return RADIANTs[host]
 
 
 def uid_to_name(uid):

--- a/radiant_test/radiant_helper.py
+++ b/radiant_test/radiant_helper.py
@@ -1,12 +1,11 @@
 import stationrc.remote_control
-from collections import defaultdict
 
 
 RADIANT_NUM_CHANNELS = 24
 RADIANT_NUM_QUADS = 3
 RADIANT_SAMPLING_RATE = 3.2  # GHz
 
-RADIANTs = defaultdict(None)
+RADIANTs = {}
 
 uid_to_name_dict = {
     "e7e318ffb2ad88e35055334a3b82ba18": "ULB-002",
@@ -50,8 +49,8 @@ def quad_for_channel(channel_id):
 def get_radiant(host=None):
     global RADIANTs
 
-    if RADIANTs[host] is None:
-        RADIANTs[host] = stationrc.remote_control.VirtualStation(host)
+    if host not in RADIANTs:
+        RADIANTs[host] = stationrc.remote_control.VirtualStation(host=host)
 
     return RADIANTs[host]
 

--- a/radiant_test/run.py
+++ b/radiant_test/run.py
@@ -2,12 +2,14 @@ from .RADIANTTest import RADIANTTest
 from .radiant_helper import get_radiant
 
 
-def run(test_class, kwargs={}):
+def run(test_class, kwargs={}, host=None):
     test = test_class(**kwargs)
 
     if issubclass(test_class, RADIANTTest):
-        test.device = get_radiant()
+        test.device = get_radiant(host)
+
     test.initialize()
     test.run()
     test.finalize()
+
     return test

--- a/run_test.py
+++ b/run_test.py
@@ -3,15 +3,32 @@ import logging
 import time
 import radiant_test
 
+def run(args, host):
+    for test in args.tests:
+        test_class = getattr(module, test)
+        t0 = time.time()
+        test_obj = radiant_test.run(test_class, {"comment": args.comment}, host=host)
+        logging.info(f"Test {test} finished in {time.time() - t0:.2f} s")
+        if args.plot:
+            scripts = __import__("scripts")
+            try:
+                import os
+                script = getattr(scripts, test + "_plot")
+                print(f"Run python {script.__file__} {test_obj.fname}")
+                os.system(f"python {script.__file__} {test_obj.fname}")
+            except AttributeError:
+                print(f"Not plotting script for {test} found!")
+
 module = __import__("tests")
 tests = [t for t in module.__dir__() if not t.startswith("__")]
 
 parser = argparse.ArgumentParser()
 parser.add_argument("tests", type=str, nargs="+", choices=tests, help="Test to execute")
 parser.add_argument("--comment", type=str, default=None, help="add a comment to the result dict of every test")
-parser.add_argument("--host", type=str, default=None,
+parser.add_argument("--host", "--hosts", dest="hosts", type=str, default=[None], nargs="+",
                     help="Specify ip address of host. If `None`, use ip from config in stationrc.")
 parser.add_argument("--debug", action="store_true", help="Set logger setting to DEBUG")
+parser.add_argument("--parallel", action="store_true", help="Set logger setting to DEBUG")
 parser.add_argument("--plot", action="store_true", help="Run the plotting script (if available)")
 args = parser.parse_args()
 
@@ -20,17 +37,9 @@ if args.debug:
 else:
     logging.basicConfig(level=logging.INFO)
 
-for test in args.tests:
-    test_class = getattr(module, test)
-    t0 = time.time()
-    test_obj = radiant_test.run(test_class, {"comment": args.comment}, host=args.host)
-    logging.info(f"Test {test} finished in {time.time() - t0:.2f} s")
-    if args.plot:
-        scripts = __import__("scripts")
-        try:
-            import os
-            script = getattr(scripts, test + "_plot")
-            print(f"Run python {script.__file__} {test_obj.fname}")
-            os.system(f"python {script.__file__} {test_obj.fname}")
-        except AttributeError:
-            print(f"Not plotting script for {test} found!")
+if args.parallel:
+    raise NotImplementedError("Parallel mode is not yet implemented")
+
+else:
+    for host in args.hosts:
+        run(args, host)

--- a/run_test.py
+++ b/run_test.py
@@ -9,6 +9,8 @@ tests = [t for t in module.__dir__() if not t.startswith("__")]
 parser = argparse.ArgumentParser()
 parser.add_argument("tests", type=str, nargs="+", choices=tests, help="Test to execute")
 parser.add_argument("--comment", type=str, default=None, help="add a comment to the result dict of every test")
+parser.add_argument("--host", type=str, default=None,
+                    help="Specify ip address of host. If `None`, use ip from config in stationrc.")
 parser.add_argument("--debug", action="store_true", help="Set logger setting to DEBUG")
 parser.add_argument("--plot", action="store_true", help="Run the plotting script (if available)")
 args = parser.parse_args()
@@ -21,7 +23,7 @@ else:
 for test in args.tests:
     test_class = getattr(module, test)
     t0 = time.time()
-    test_obj = radiant_test.run(test_class, {"comment": args.comment})
+    test_obj = radiant_test.run(test_class, {"comment": args.comment}, host=args.host)
     logging.info(f"Test {test} finished in {time.time() - t0:.2f} s")
     if args.plot:
         scripts = __import__("scripts")


### PR DESCRIPTION
Factorize the `run_test.py` script to be able to run it for several hosts in one go. Add caching for several radiants